### PR TITLE
add badge to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# doThis
+
+## Links
+
+![Coverage](.github/badges/jacoco.svg)


### PR DESCRIPTION
This should add a coverage badge to the readme of the project

see docs: https://github.com/cicirello/jacoco-badge-generator?tab=readme-ov-file#adding-the-badges-to-your-readme
